### PR TITLE
Use EPSG:3857 for Rephotography map layer

### DIFF
--- a/projects/rephotography/MapView.vue
+++ b/projects/rephotography/MapView.vue
@@ -113,7 +113,7 @@ const toggleMapLayer = () => {
       <MapComponent :min-zoom="9" :max-zoom="16" :restrictExtent="[0.0, 75.0, 30.0, 81.0]" >
         <template #layers>
           <NpolarLayer
-            capabilitiesUrl="https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+            capabilitiesUrl="https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_3857/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
           />
 
         <!-- places -->

--- a/projects/rephotography/NpolarLayer.vue
+++ b/projects/rephotography/NpolarLayer.vue
@@ -1,8 +1,5 @@
 <script lang="ts" setup>
 import { ref } from "vue";
-import proj4 from "proj4";
-import { get as getProjection } from "ol/proj";
-import { register } from "ol/proj/proj4";
 import { type Options, optionsFromCapabilities } from "ol/source/WMTS";
 import axios from "axios";
 import { WMTSCapabilities } from "ol/format";
@@ -17,13 +14,6 @@ const props = defineProps({
 
 const options = ref<Options>();
 
-proj4.defs(
-  "EPSG:25833",
-  "+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs"
-);
-register(proj4);
-const projection = getProjection("EPSG:25833");
-
 (async () => {
   const response = await axios.get(props.capabilitiesUrl);
   const parser = new WMTSCapabilities();
@@ -31,7 +21,6 @@ const projection = getProjection("EPSG:25833");
   options.value =
     optionsFromCapabilities(capabilities, {
       layer: capabilities.Contents.Layer[0].Identifier,
-      projection,
     }) || undefined;
 })();
 </script>


### PR DESCRIPTION
I was in contact with Norsk Polarinstitutt to ask for support when adding their map layers to the Rephotography project. I had problems with the projection, and I eventually got it right. In May, they let me know that they have added a version of the map layer which uses EPSG:3857. By switching to that one, we can omit some custom code.